### PR TITLE
Release Versioning Specification

### DIFF
--- a/index.md
+++ b/index.md
@@ -42,6 +42,7 @@ The sponsor is responsible for managing the review stage and votes.
 | N/A | [Simplify Admin Views*][simplify-admin]  | Elisa Foltyn <elisa.foltyn@community.joomla.org> | N/A |
 | N/A | [Simplify Admin Views*][simplify-admin2]  | Astrid Günther <astrid.guenther@community.joomla.org> | N/A |
 | N/A | [Composer support][composer]  | Astrid Günther <astrid.guenther@community.joomla.org> | N/A |
+| N/A | [Release Versioning][release-versioning]  | Niels Braczek <niels.braczek@community.joomla.org> | Harald Leithner <harald.leithner@community.joomla.org> |
 
 *) Two different proposals on the same target, need to be merged 
 
@@ -68,3 +69,4 @@ _**Legend:** A = Accepted | D = Draft | P = Pre-Draft | R = Review | X = Depreca
 [simplify-admin2]: https://github.com/joomla-x/joomla-standards/pull/7
 [composer]: https://github.com/joomla-x/joomla-standards/pull/8
 [rfc-procedure]: https://github.com/joomla-x/joomla-standards/blob/master/accepted/RFC-0-rfc-meta.md
+[release-versioning]: https://github.com/joomla-x/joomla-Specifications/tree/master/proposed

--- a/proposed/release-versioning-meta.md
+++ b/proposed/release-versioning-meta.md
@@ -1,0 +1,101 @@
+# Release Versioning Meta Document
+
+## 1. Summary
+
+_This Specification describes how versions are numbered in Joomla projects._
+
+This specification aims to help developers, code reviewers and release leads to determine, whether a new piece or a
+change of code belongs to the next patch, minor or major release. It will also cover documentation requirements that are
+related to versioning.
+
+## 2. Why Bother?
+
+Sometimes it is hard to tell bug fixes and features apart. The Release Leads want a comprehensive set of rules to be
+able to make good and fast decisions about the target release of a contribution.
+
+## 3. Scope
+
+The specification applies to all Joomla projects, e.g., the CMS, the Framework, core extensions, ...
+
+## 4. Considerations
+
+### 4.1 Semantic Versioning
+
+Joomla started to follow [Semantic Versioning](Semver) with release 3.3 in April 2014. The rules were not always
+followed strictly ([Issue#16874](16874), [Issue#17583](17583), [Issue#24728](24728) to name a few). This need to change,
+because the Joomla ecosystem is heavily depending on reliable information about compatibility. This is done in section 1
+of the specification.
+
+[Semver]: https://github.com/semver/semver/blob/master/semver.md
+
+[24728]: https://issues.joomla.org/tracker/joomla-cms/24728
+
+[17583]: https://github.com/joomla/joomla-cms/issues/17583
+
+[16874]: https://github.com/joomla/joomla-cms/issues/16874
+
+### 4.2 API
+
+The main problem with Semantic Versioning seems to be to categorise code contributions as bug fixes or features. This
+should be easy enough, as the Semantic Versioning specification is quite clear in that regard. Strongly simplified, it
+says: Changes that do not change signatures of functions or methods of the public API and do not add new ones can go
+into a patch release.
+
+Unfortunately, Joomla has no official definition of "public API". Section 2 of the specification makes up for the
+omission. It describes, how public and internal API are told apart using the `@api` and `@internal` annotations as
+proposed by the draft [PSR19][]. It is recommended to add these annotations to existing code. For new code they are
+required.
+
+[PSR19]: https://github.com/php-fig/fig-standards/blob/master/proposed/phpdoc-tags.md
+
+### 4.3 Deprecations
+
+The core contributors have not been very cautious about deprecations in the past.
+`JObject`, for example, has
+been [deprecated for Joomla 3.4](https://github.com/joomla/joomla-cms/issues/6125#issuecomment-75035212), but made it
+into Joomla 4 (although renamed to CMSObject) with the deprecation annotation still in place. Section 3 describes how to
+handle and document deprecations. Among other things, it stipulates that a replacement must be offered and used, if the
+deprecation is not phasing out a feature. The documentation requirements make sure that legacy code can easily be
+adopted to the new implementation.
+
+### 4.4 User Interface
+
+From a code point of view, improvements of the user interface do not touch the API and thus are not features in the
+sense of Semantic Versioning. Template files, however, work like functions, since they rely on injected variables to
+produce the output. This interface between a View and a template is a contract and as such underlies the rules of
+Semantic Versioning. Section 4 provides the rules for dealing with user interface changes.
+
+### 4.5 External Dependencies
+
+Section 5 deals with external dependencies, a.k.a. libraries. The implementation details of external dependencies are not under the control of the Joomla project. Therefore, the code
+of these dependencies is basically internal and does not fall under Semantic Versioning. As a result, these dependencies
+can be updated or even exchanged without breaking the compatibility promise. As soon as an external API officially becomes part of the
+public API, as in the case of Bootstrap, the rules of Semantic Versioning do apply.
+
+## 5. People
+
+### 5.1 Editor(s)
+
+* Niels Braczek <niels.braczek@community.joomla.org>
+
+### 5.2 Sponsors
+
+* Harald Leithner <harald.leithner@community.joomla.org>
+
+### 5.3 Contributors
+
+* N/A
+
+## 6. Votes
+
+* **Entrance Vote:** 2021-11-16 Production Team Leaders
+* **Acceptance Vote:** _(not yet taken)_
+
+## 7. Relevant Links
+
+_**Note:** Order descending chronologically._
+* [Semantic Versioning Specification](Semver)
+
+## 8. Errata
+
+...

--- a/proposed/release-versioning.md
+++ b/proposed/release-versioning.md
@@ -1,0 +1,116 @@
+# Release Versioning
+
+This specification describes how versions are numbered in Joomla projects. It also defines documentation requirements
+related to versioning.
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in [RFC 2119][].
+
+[RFC 2119]: https://www.rfc-editor.org/rfc/rfc2119.html
+
+### Definitions
+
+* "Structural Element" is a collection of Programming Constructs which MAY be preceded by a DocBlock. The collection
+  contains the following constructs:
+    * class
+    * interface
+    * trait
+    * function (including methods)
+    * property
+    * constant
+    * variables, both local and global scope.
+
+### References
+
+- [RFC 2119][]: Key words for use in RFCs to Indicate Requirement Levels
+
+## Specification
+
+### 1 Semantic Versioning
+
+1. All releases in all Joomla projects MUST strictly follow the [Semantic Versioning](Semver) specification in its
+   current version.
+
+[Semver]: https://github.com/semver/semver/blob/master/semver.md
+
+### 2 API
+
+Because Semantic Versioning applies to public API only, a distinction between public and internal API is needed.
+
+#### 2.1 Public API
+
+"Public API" describes the sum of structural elements that MAY be used by extension developers.
+
+1. Changes to the public API are subject to the rules of semantic versioning.
+2. In order to distinguish these elements from the internal elements, the following applies:
+    1. Existing public structural elements SHOULD be annotated with `@api` in the corresponding DocBlock.
+    1. Newly introduced public structural elements MUST be annotated with `@api` in the corresponding DocBlock.
+    2. Public structural elements MUST be included in the official documentation.
+
+#### 2.2 Internal API
+
+The "Internal API" comprises the structural elements that are supportive for the core and SHOULD NOT be used by
+extension developers.
+
+1. Changes to the internal API are not subject to the rules of semantic versioning.
+2. In order to distinguish these elements from the public elements, the following applies:
+    1. Existing internal structural elements SHOULD be annotated with `@internal` in the corresponding DocBlock.
+    1. Newly introduced structural elements MUST be annotated with `@internal` in the corresponding DocBlock.
+    2. Structural elements with the access modifier `private` and structural elements in final classes with the access
+       modifier `protected` MUST be treated as internal.
+    3. Internal structural elements MUST NOT be included in the official documentation. All documentation needed by core
+       developers SHOULD be available in the corresponding DocBlock.
+
+### 3 Deprecations
+
+Deprecating existing functionality is a normal part of software development and is often required to make forward
+progress. There are two reasons to deprecate code: (1) architectural changes or (2) removal of features. This section
+applies to public API only.
+
+#### 3.1 Architectural Changes
+
+1. The official documentation MUST be updated to let users know about the change.
+    1. The DocBlock MUST be annotated to document the replacement for the deprecated element. The deprecation annotation
+       SHOULD be supplemented by a usage example for the replacement. Example:
+       ```php
+       /**
+        * ...
+        * @deprecated X.Y  Will be removed in X+1.0. Use <replacement> instead. 
+        *                  Before (version < X.Y):
+        *                  <sample code with deprecated element>
+        *                  After (version >= X.Y):
+        *                  <sample code using the replacement>
+        */
+       ```
+       with X.Y being the minor version introducing the deprecation.
+2. A new minor release MUST be issued with the deprecation in place. That release MUST NOT use the deprecated code
+   anywhere.
+3. The deprecated code MUST be removed in the next major release.
+
+#### 3.2 Phasing out Features
+
+1. The official documentation MUST be updated to let users know about the change.
+    1. The DocBlock MUST be annotated to document the replacement for the deprecated element. The deprecation annotation
+       SHOULD be supplemented by a recommendation for an alternative. Example:
+       ```php
+       /**
+        * ...
+        * @deprecated X.Y  Will be removed in X+1.0 without replacement. 
+        *                  Please consider using <solution A> or <solution B> instead.
+        */
+       ```
+       with X.Y being the minor version introducing the deprecation.
+2. A new minor release MUST be issued with the deprecation in place. That release MUST NOT use the deprecated code
+   anywhere.
+3. The deprecated code MUST be removed in the next major release.
+
+### 4 User Interface
+
+1. Changes to the user interface are considered compatible if they do not affect the public API.
+2. If variables passed to or required by template files change, it MUST be treated as a change of the public API.
+
+### 5 External Dependencies
+
+1. Updating external dependencies is considered compatible since it does not affect the public API.
+2. The API of the dependencies is not part of the project's API, unless explicitly stated in the official documentation.
+3. Extension developers MUST NOT rely on the presence of dependencies that are not covered in the official documentation.


### PR DESCRIPTION
## 1. Summary

_This Specification describes how versions are numbered in Joomla projects._

This specification aims to help developers, code reviewers and release leads to determine, whether a new piece or a
change of code belongs to the next patch, minor or major release. It will also cover documentation requirements that are
related to versioning.

## 2. Why Bother?

Sometimes it is hard to tell bug fixes and features apart. The Release Leads want a comprehensive set of rules to be
able to make good and fast decisions about the target release of a contribution.
