### PR TITLE
Decoupling Output

### DIFF
--- a/proposed/decoupling-output-meta.md
+++ b/proposed/decoupling-output-meta.md
@@ -1,0 +1,65 @@
+# Decoupling Output Meta Document
+
+## 1. Summary
+
+_The separation of the visual preparation and presentation of the content from its management is what we call
+decoupling of the output._
+
+The aim of this specification is to decouple the output layer from the core of the CMS so that necessary changes to the
+CMS code require as few changes as possible to the templates and their overrides.
+
+## 2. Why Bother?
+
+Every major version so far has stirred up resentment among users because not only programme code but also templates,
+layouts and overrides had to be revised. If we succeed in reducing the points of contact between the CMS core and the
+actual views to interfaces, not only will the adaptation effort for templates, layouts and overrides be considerably
+less, it will even be possible to offer output layers with completely different frontend libraries than before.
+
+## 3. Scope
+
+### 3.1 Goals
+
+### 3.2 Non-Goals
+
+## 4. Approaches
+
+### 4.1 Approach 1
+
+#### 4.1.1 Projects Using Approach 1
+
+### 4.2 Approach 2
+
+#### 4.2.1 Projects Using Approach 2
+
+### 4.3 Comparison of Approaches
+
+### 4.4 Chosen Approach
+
+## 5. Design Decisions
+
+## 6. People
+
+### 6.1 Editor(s)
+
+* Niels Braczek <niels.braczek@community.joomla.org>
+
+### 6.2 Sponsors
+
+* N/A
+
+### 6.3 Contributors
+
+* N/A
+
+## 7. Votes
+
+* **Entrance Vote:** _(not yet taken)_
+* **Acceptance Vote:** _(not yet taken)_
+
+## 8. Relevant Links
+
+_**Note:** Order descending chronologically._
+
+## 9. Errata
+
+...

--- a/proposed/decoupling-output.md
+++ b/proposed/decoupling-output.md
@@ -1,0 +1,45 @@
+# Decoupling Output
+
+This document describes ...
+
+The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+"SHOULD NOT", "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be
+interpreted as described in [RFC 2119][].
+
+[RFC 2119]: http://tools.ietf.org/html/rfc2119
+
+### References
+
+- [RFC 2119][]: Key words for use in RFCs to Indicate Requirement Levels
+
+## 1. Specification
+
+### 1.1 Spec A
+
+### 1.2 Spec B
+
+## 2. Interfaces
+
+### 2.1 Interface A
+
+The following interface MUST be implemented by compatible ...
+
+```php
+namespace ...;
+
+interface ...
+{
+}
+```
+
+### 2.2 Inteface B
+
+The following interface MUST be implemented by compatible ...
+
+```php
+namespace ...;
+
+interface ...
+{
+}
+```


### PR DESCRIPTION

## 1. Summary

_The separation of the visual preparation and presentation of the content from its management is what we call
decoupling of the output._

The aim of this specification is to decouple the output layer from the core of the CMS so that necessary changes to the
CMS code require as few changes as possible to the templates and their overrides.

## 2. Why Bother?

Every major version so far has stirred up resentment among users because not only programme code but also templates,
layouts and overrides had to be revised. If we succeed in reducing the points of contact between the CMS core and the
actual views to interfaces, not only will the adaptation effort for templates, layouts and overrides be considerably
less, it will even be possible to offer output layers with completely different frontend libraries than before.

**The solution developed here is to be incorporated into Joomla 5.**